### PR TITLE
[Merging hgoes's fork] Fix parsing of escaped characters in attribute values

### DIFF
--- a/src/XmlParser.elm
+++ b/src/XmlParser.elm
@@ -350,7 +350,7 @@ textString end_ =
             |> andThen
                 (\s ->
                     oneOf
-                        [ succeed String.cons
+                        [ succeed (\c cs -> s++String.cons c cs)
                             |= escapedChar end_
                             |= lazy (\_ -> textString end_)
                         , succeed s


### PR DESCRIPTION
The textString function discarded all text prior to an escaped
character.