### PR TITLE
Don't escape processing instruction value in the `format` function.

### DIFF
--- a/src/XmlParser.elm
+++ b/src/XmlParser.elm
@@ -560,7 +560,7 @@ format xml =
 
 formatProcessingInstruction : ProcessingInstruction -> String
 formatProcessingInstruction processingInstruction =
-    "<?" ++ escape processingInstruction.name ++ " " ++ escape processingInstruction.value ++ "?>"
+    "<?" ++ escape processingInstruction.name ++ " " ++ processingInstruction.value ++ "?>"
 
 
 formatDocType : DocType -> String

--- a/tests/XmlParserTest.elm
+++ b/tests/XmlParserTest.elm
@@ -180,6 +180,13 @@ suite =
                     Nothing
                     (Element "a" [] [])
                 )
+        , test "format 10" <|
+            testFormat
+                (Xml
+                    [ ProcessingInstruction "xml" "version=\"1.0\"" ]
+                    Nothing
+                    (Element "a" [] [])
+                )
         ]
 
 


### PR DESCRIPTION
With escaping enabled "format 10" test was failing with:

```
✗ format 10

    { processingInstructions = [{ name = "xml", value = "version=&quot;1.0&quot;" }], docType = Nothing, root = Element "a" [] [] }
    ╷
    │ Expect.equal
    ╵
    { processingInstructions = [{ name = "xml", value = "version=\"1.0\"" }], docType = Nothing, root = Element "a" [] [] }
```